### PR TITLE
feat: Refactor index page to include layout and component structure

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,20 @@
 ---
-import { defaultLang } from '../i18n/ui';
-
-// Redirect to default language
-return Astro.redirect(`/${defaultLang}`);
+import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import Home from '../components/Home.astro';
+import HomePresentation from '../components/HomePresentation.astro';
+import HomeGuide from '../components/HomeGuide.astro';
+import Feature from '../components/Feature.astro';
+import Footer from '../components/Footer.astro';
 ---
+
+<Layout title="AutoFix - Plataforma Digital Automotriz">
+	<Header />
+	<main>
+		<Home />
+		<HomePresentation />
+		<HomeGuide />
+		<Feature />
+	</main>
+	<Footer />
+</Layout>


### PR DESCRIPTION
This pull request updates the root page implementation in `src/pages/index.astro` to render the main landing page content directly, instead of redirecting to the default language route. The new approach uses a composition of layout and component files to build the homepage.

Landing page rendering:

* Replaced the redirect to the default language with a rendered homepage, using the `Layout`, `Header`, `Home`, `HomePresentation`, `HomeGuide`, `Feature`, and `Footer` components for a complete landing experience.